### PR TITLE
Add versionIRI metadata to nmrCV.owl release file

### DIFF
--- a/cv/v1.1.0/nmrCV.owl
+++ b/cv/v1.1.0/nmrCV.owl
@@ -137,6 +137,7 @@ A paper describing the overall nmrML data standard and CV has been accepted by A
 `nmrML: a community supported open data standard for the description, storage, and exchange of NMR data`, author(s): Schober, Daniel; Jacob, Daniel; Wilson, Michael; Cruz, Joseph; Marcu, Ana; Grant, Jason; Moing, Annick; Deborde, Catherine; de Figueiredo, Luis; Haug, Kenneth; Rocca-Serra, Philippe; Easton, John; Ebbels, Timothy; Hao, Jie; Ludwig, Christian; Günther, Ulrich; Rosato, Antonio; Klein, Matthias; Lewis, Ian; Luchinat, Claudio; Jones, Andrew; Grauslys, Arturas; Larralde, Martin; Yokochi, Masashi; Kobayashi, Naohiro; Porzel, Andrea; Griffin, Julian; Viant, Mark; Wishart, David; Steinbeck, Christoph; Salek, Reza; Neumann, Steffen</dc:contributor>
         <doap:implements rdf:datatype="http://www.w3.org/2001/XMLSchema#string">https://github.com/nmrML/nmrML</doap:implements>
         <dc:contributor rdf:datatype="http://www.w3.org/2001/XMLSchema#string">Annick Moing</dc:contributor>
+        <owl:versionIRI rdf:resource="http://nmrml.org/cv/v1.1.0/nmrCV.owl"/>
     </owl:Ontology>
     
 


### PR DESCRIPTION
This PR edits the `nmrCV.owl` release file living under `https://github.com/nmrML/nmrML/blob/gh-pages/cv/v1.1.0/nmrCV.owl`, which, I assume, was copied into the webspace of the nmrML.org website to this path `http://nmrml.org/cv/v1.1.0/nmrCV.owl`, from where nmrCV is served.
It adds an `owl: versionIRI` metadata assertion that points to `http://nmrml.org/cv/v1.1.0/nmrCV.owl` as the version IRI. This ensures that at least the version IRI within the nmrCV.owl is resolvable, once this PR is accepted and this file is overwritten on the nmrml.org server. 
So this PR is a small step in the direction of addressing https://github.com/nmrML/nmrCV/issues/23.
It also fixes #189 partially.  Partially, because this addition should also be done on the source itself (https://github.com/nmrML/nmrML/blob/master/ontologies/nmrCV.owl) to ensure that this edit persists, once the automatic doc build pipeline (about which I know nothing) would be rerun, and its GH-pages output would be copied back onto the nmrml.org server.  