### PR TITLE
Update 2025 release metadata

### DIFF
--- a/cv/2025-03-20/nmrCV-base.obo
+++ b/cv/2025-03-20/nmrCV-base.obo
@@ -31,15 +31,15 @@ property_value: dcterms:contributor https://orcid.org/0000-0003-1144-3600
 property_value: dcterms:contributor https://orcid.org/0009-0001-5998-5030
 property_value: dcterms:created "2025-03-20" xsd:string
 property_value: dcterms:license https://creativecommons.org/publicdomain/mark/1.0/
-property_value: dcterms:references "https://doi.org/10.1021/acs.analchem.7b02795" xsd:string
+property_value: dcterms:references https://doi.org/10.1021/acs.analchem.7b02795
 property_value: dcterms:title "nuclear magnetic resonance CV" xsd:string
 property_value: doap:audience "This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments." xsd:string
-property_value: doap:bug-database "https://github.com/nmrML/nmrCV/issues" xsd:string
-property_value: doap:implements "https://github.com/nmrML/nmrML" xsd:string
-property_value: doap:location "https://github.com/nmrML/nmrCV" xsd:string
+property_value: doap:bug-database "https://github.com/nmrML/nmrCV/issues" xsd:anyURI
+property_value: doap:implements https://github.com/nmrML/nmrML
+property_value: doap:location "https://github.com/nmrML/nmrCV" xsd:anyURI
 property_value: doap:maintainer https://www.wikidata.org/wiki/Q96678459
 property_value: owl:priorVersion https://nmrml.org/cv/v1.1.0/nmrCV.owl
 property_value: owl:versionInfo "2.0_alpha" xsd:string
 property_value: owl:versionInfo "2025-03-20" xsd:string
-property_value: vann:preferredNamespacePrefix "nmrCV" xsd:string
+property_value: vann:preferredNamespacePrefix "nmrCV2025" xsd:string
 

--- a/cv/2025-03-20/nmrCV-base.owl
+++ b/cv/2025-03-20/nmrCV-base.owl
@@ -46,13 +46,13 @@ The decision to build upon nmrCV v1.1.0 was based on its existing definition of 
         <dcterms:contributor rdf:resource="https://orcid.org/0009-0001-5998-5030"/>
         <dcterms:created>2025-03-20</dcterms:created>
         <dcterms:license rdf:resource="https://creativecommons.org/publicdomain/mark/1.0/"/>
-        <dcterms:references>https://doi.org/10.1021/acs.analchem.7b02795</dcterms:references>
+        <dcterms:references rdf:resource="https://doi.org/10.1021/acs.analchem.7b02795"/>
         <dcterms:title>nuclear magnetic resonance CV</dcterms:title>
-        <vann:preferredNamespacePrefix>nmrCV</vann:preferredNamespacePrefix>
+        <vann:preferredNamespacePrefix>nmrCV2025</vann:preferredNamespacePrefix>
         <doap:audience>This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments.</doap:audience>
-        <doap:bug-database>https://github.com/nmrML/nmrCV/issues</doap:bug-database>
-        <doap:implements>https://github.com/nmrML/nmrML</doap:implements>
-        <doap:location>https://github.com/nmrML/nmrCV</doap:location>
+        <doap:bug-database rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/nmrML/nmrCV/issues</doap:bug-database>
+        <doap:implements rdf:resource="https://github.com/nmrML/nmrML"/>
+        <doap:location rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/nmrML/nmrCV</doap:location>
         <doap:maintainer rdf:resource="https://www.wikidata.org/wiki/Q96678459"/>
         <owl:priorVersion rdf:resource="https://nmrml.org/cv/v1.1.0/nmrCV.owl"/>
         <owl:versionInfo>2.0_alpha</owl:versionInfo>

--- a/cv/2025-03-20/nmrCV-base.ttl
+++ b/cv/2025-03-20/nmrCV-base.ttl
@@ -46,13 +46,13 @@ The decision to build upon nmrCV v1.1.0 was based on its existing definition of 
                                                              <https://orcid.org/0009-0001-5998-5030> ;
                                          dcterms:created "2025-03-20" ;
                                          dcterms:license <https://creativecommons.org/publicdomain/mark/1.0/> ;
-                                         dcterms:references "https://doi.org/10.1021/acs.analchem.7b02795" ;
+                                         dcterms:references <https://doi.org/10.1021/acs.analchem.7b02795> ;
                                          dcterms:title "nuclear magnetic resonance CV" ;
-                                         vann:preferredNamespacePrefix "nmrCV" ;
+                                         vann:preferredNamespacePrefix "nmrCV2025" ;
                                          doap:audience "This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments." ;
-                                         doap:bug-database "https://github.com/nmrML/nmrCV/issues" ;
-                                         doap:implements "https://github.com/nmrML/nmrML" ;
-                                         doap:location "https://github.com/nmrML/nmrCV" ;
+                                         doap:bug-database "https://github.com/nmrML/nmrCV/issues"^^xsd:anyURI ;
+                                         doap:implements <https://github.com/nmrML/nmrML> ;
+                                         doap:location "https://github.com/nmrML/nmrCV"^^xsd:anyURI ;
                                          doap:maintainer <https://www.wikidata.org/wiki/Q96678459> ;
                                          owl:priorVersion <https://nmrml.org/cv/v1.1.0/nmrCV.owl> ;
                                          owl:versionInfo "2.0_alpha" ,

--- a/cv/2025-03-20/nmrCV-full.obo
+++ b/cv/2025-03-20/nmrCV-full.obo
@@ -55,17 +55,17 @@ property_value: dcterms:contributor https://orcid.org/0000-0003-1144-3600
 property_value: dcterms:contributor https://orcid.org/0009-0001-5998-5030
 property_value: dcterms:created "2025-03-20" xsd:string
 property_value: dcterms:license https://creativecommons.org/publicdomain/mark/1.0/
-property_value: dcterms:references "https://doi.org/10.1021/acs.analchem.7b02795" xsd:string
+property_value: dcterms:references https://doi.org/10.1021/acs.analchem.7b02795
 property_value: dcterms:title "nuclear magnetic resonance CV" xsd:string
 property_value: doap:audience "This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments." xsd:string
-property_value: doap:bug-database "https://github.com/nmrML/nmrCV/issues" xsd:string
-property_value: doap:implements "https://github.com/nmrML/nmrML" xsd:string
-property_value: doap:location "https://github.com/nmrML/nmrCV" xsd:string
+property_value: doap:bug-database "https://github.com/nmrML/nmrCV/issues" xsd:anyURI
+property_value: doap:implements https://github.com/nmrML/nmrML
+property_value: doap:location "https://github.com/nmrML/nmrCV" xsd:anyURI
 property_value: doap:maintainer https://www.wikidata.org/wiki/Q96678459
 property_value: owl:priorVersion https://nmrml.org/cv/v1.1.0/nmrCV.owl
 property_value: owl:versionInfo "2.0_alpha" xsd:string
 property_value: owl:versionInfo "2025-03-20" xsd:string
-property_value: vann:preferredNamespacePrefix "nmrCV" xsd:string
+property_value: vann:preferredNamespacePrefix "nmrCV2025" xsd:string
 
 [Term]
 id: BFO:0000001

--- a/cv/2025-03-20/nmrCV-full.owl
+++ b/cv/2025-03-20/nmrCV-full.owl
@@ -53,13 +53,13 @@ The decision to build upon nmrCV v1.1.0 was based on its existing definition of 
         <dcterms:contributor rdf:resource="https://orcid.org/0009-0001-5998-5030"/>
         <dcterms:created>2025-03-20</dcterms:created>
         <dcterms:license rdf:resource="https://creativecommons.org/publicdomain/mark/1.0/"/>
-        <dcterms:references>https://doi.org/10.1021/acs.analchem.7b02795</dcterms:references>
+        <dcterms:references rdf:resource="https://doi.org/10.1021/acs.analchem.7b02795"/>
         <dcterms:title>nuclear magnetic resonance CV</dcterms:title>
-        <vann:preferredNamespacePrefix>nmrCV</vann:preferredNamespacePrefix>
+        <vann:preferredNamespacePrefix>nmrCV2025</vann:preferredNamespacePrefix>
         <doap:audience>This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments.</doap:audience>
-        <doap:bug-database>https://github.com/nmrML/nmrCV/issues</doap:bug-database>
-        <doap:implements>https://github.com/nmrML/nmrML</doap:implements>
-        <doap:location>https://github.com/nmrML/nmrCV</doap:location>
+        <doap:bug-database rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/nmrML/nmrCV/issues</doap:bug-database>
+        <doap:implements rdf:resource="https://github.com/nmrML/nmrML"/>
+        <doap:location rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/nmrML/nmrCV</doap:location>
         <doap:maintainer rdf:resource="https://www.wikidata.org/wiki/Q96678459"/>
         <owl:priorVersion rdf:resource="https://nmrml.org/cv/v1.1.0/nmrCV.owl"/>
         <owl:versionInfo>2.0_alpha</owl:versionInfo>

--- a/cv/2025-03-20/nmrCV-full.ttl
+++ b/cv/2025-03-20/nmrCV-full.ttl
@@ -53,13 +53,13 @@ The decision to build upon nmrCV v1.1.0 was based on its existing definition of 
                                                              <https://orcid.org/0009-0001-5998-5030> ;
                                          dcterms:created "2025-03-20" ;
                                          dcterms:license <https://creativecommons.org/publicdomain/mark/1.0/> ;
-                                         dcterms:references "https://doi.org/10.1021/acs.analchem.7b02795" ;
+                                         dcterms:references <https://doi.org/10.1021/acs.analchem.7b02795> ;
                                          dcterms:title "nuclear magnetic resonance CV" ;
-                                         vann:preferredNamespacePrefix "nmrCV" ;
+                                         vann:preferredNamespacePrefix "nmrCV2025" ;
                                          doap:audience "This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments." ;
-                                         doap:bug-database "https://github.com/nmrML/nmrCV/issues" ;
-                                         doap:implements "https://github.com/nmrML/nmrML" ;
-                                         doap:location "https://github.com/nmrML/nmrCV" ;
+                                         doap:bug-database "https://github.com/nmrML/nmrCV/issues"^^xsd:anyURI ;
+                                         doap:implements <https://github.com/nmrML/nmrML> ;
+                                         doap:location "https://github.com/nmrML/nmrCV"^^xsd:anyURI ;
                                          doap:maintainer <https://www.wikidata.org/wiki/Q96678459> ;
                                          owl:priorVersion <https://nmrml.org/cv/v1.1.0/nmrCV.owl> ;
                                          owl:versionInfo "2.0_alpha" ,

--- a/cv/2025-03-20/nmrCV.obo
+++ b/cv/2025-03-20/nmrCV.obo
@@ -55,17 +55,17 @@ property_value: dcterms:contributor https://orcid.org/0000-0003-1144-3600
 property_value: dcterms:contributor https://orcid.org/0009-0001-5998-5030
 property_value: dcterms:created "2025-03-20" xsd:string
 property_value: dcterms:license https://creativecommons.org/publicdomain/mark/1.0/
-property_value: dcterms:references "https://doi.org/10.1021/acs.analchem.7b02795" xsd:string
+property_value: dcterms:references https://doi.org/10.1021/acs.analchem.7b02795
 property_value: dcterms:title "nuclear magnetic resonance CV" xsd:string
 property_value: doap:audience "This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments." xsd:string
-property_value: doap:bug-database "https://github.com/nmrML/nmrCV/issues" xsd:string
-property_value: doap:implements "https://github.com/nmrML/nmrML" xsd:string
-property_value: doap:location "https://github.com/nmrML/nmrCV" xsd:string
+property_value: doap:bug-database "https://github.com/nmrML/nmrCV/issues" xsd:anyURI
+property_value: doap:implements https://github.com/nmrML/nmrML
+property_value: doap:location "https://github.com/nmrML/nmrCV" xsd:anyURI
 property_value: doap:maintainer https://www.wikidata.org/wiki/Q96678459
 property_value: owl:priorVersion https://nmrml.org/cv/v1.1.0/nmrCV.owl
 property_value: owl:versionInfo "2.0_alpha" xsd:string
 property_value: owl:versionInfo "2025-03-20" xsd:string
-property_value: vann:preferredNamespacePrefix "nmrCV" xsd:string
+property_value: vann:preferredNamespacePrefix "nmrCV2025" xsd:string
 
 [Term]
 id: BFO:0000001

--- a/cv/2025-03-20/nmrCV.owl
+++ b/cv/2025-03-20/nmrCV.owl
@@ -53,13 +53,13 @@ The decision to build upon nmrCV v1.1.0 was based on its existing definition of 
         <dcterms:contributor rdf:resource="https://orcid.org/0009-0001-5998-5030"/>
         <dcterms:created>2025-03-20</dcterms:created>
         <dcterms:license rdf:resource="https://creativecommons.org/publicdomain/mark/1.0/"/>
-        <dcterms:references>https://doi.org/10.1021/acs.analchem.7b02795</dcterms:references>
+        <dcterms:references rdf:resource="https://doi.org/10.1021/acs.analchem.7b02795"/>
         <dcterms:title>nuclear magnetic resonance CV</dcterms:title>
-        <vann:preferredNamespacePrefix>nmrCV</vann:preferredNamespacePrefix>
+        <vann:preferredNamespacePrefix>nmrCV2025</vann:preferredNamespacePrefix>
         <doap:audience>This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments.</doap:audience>
-        <doap:bug-database>https://github.com/nmrML/nmrCV/issues</doap:bug-database>
-        <doap:implements>https://github.com/nmrML/nmrML</doap:implements>
-        <doap:location>https://github.com/nmrML/nmrCV</doap:location>
+        <doap:bug-database rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/nmrML/nmrCV/issues</doap:bug-database>
+        <doap:implements rdf:resource="https://github.com/nmrML/nmrML"/>
+        <doap:location rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/nmrML/nmrCV</doap:location>
         <doap:maintainer rdf:resource="https://www.wikidata.org/wiki/Q96678459"/>
         <owl:priorVersion rdf:resource="https://nmrml.org/cv/v1.1.0/nmrCV.owl"/>
         <owl:versionInfo>2.0_alpha</owl:versionInfo>

--- a/cv/2025-03-20/nmrCV.ttl
+++ b/cv/2025-03-20/nmrCV.ttl
@@ -53,13 +53,13 @@ The decision to build upon nmrCV v1.1.0 was based on its existing definition of 
                                                   <https://orcid.org/0009-0001-5998-5030> ;
                               dcterms:created "2025-03-20" ;
                               dcterms:license <https://creativecommons.org/publicdomain/mark/1.0/> ;
-                              dcterms:references "https://doi.org/10.1021/acs.analchem.7b02795" ;
+                              dcterms:references <https://doi.org/10.1021/acs.analchem.7b02795> ;
                               dcterms:title "nuclear magnetic resonance CV" ;
-                              vann:preferredNamespacePrefix "nmrCV" ;
+                              vann:preferredNamespacePrefix "nmrCV2025" ;
                               doap:audience "This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments." ;
-                              doap:bug-database "https://github.com/nmrML/nmrCV/issues" ;
-                              doap:implements "https://github.com/nmrML/nmrML" ;
-                              doap:location "https://github.com/nmrML/nmrCV" ;
+                              doap:bug-database "https://github.com/nmrML/nmrCV/issues"^^xsd:anyURI ;
+                              doap:implements <https://github.com/nmrML/nmrML> ;
+                              doap:location "https://github.com/nmrML/nmrCV"^^xsd:anyURI ;
                               doap:maintainer <https://www.wikidata.org/wiki/Q96678459> ;
                               owl:priorVersion <https://nmrml.org/cv/v1.1.0/nmrCV.owl> ;
                               owl:versionInfo "2.0_alpha" ,

--- a/nmrCV-base.obo
+++ b/nmrCV-base.obo
@@ -31,15 +31,15 @@ property_value: dcterms:contributor https://orcid.org/0000-0003-1144-3600
 property_value: dcterms:contributor https://orcid.org/0009-0001-5998-5030
 property_value: dcterms:created "2025-03-20" xsd:string
 property_value: dcterms:license https://creativecommons.org/publicdomain/mark/1.0/
-property_value: dcterms:references "https://doi.org/10.1021/acs.analchem.7b02795" xsd:string
+property_value: dcterms:references https://doi.org/10.1021/acs.analchem.7b02795
 property_value: dcterms:title "nuclear magnetic resonance CV" xsd:string
 property_value: doap:audience "This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments." xsd:string
-property_value: doap:bug-database "https://github.com/nmrML/nmrCV/issues" xsd:string
-property_value: doap:implements "https://github.com/nmrML/nmrML" xsd:string
-property_value: doap:location "https://github.com/nmrML/nmrCV" xsd:string
+property_value: doap:bug-database "https://github.com/nmrML/nmrCV/issues" xsd:anyURI
+property_value: doap:implements https://github.com/nmrML/nmrML
+property_value: doap:location "https://github.com/nmrML/nmrCV" xsd:anyURI
 property_value: doap:maintainer https://www.wikidata.org/wiki/Q96678459
 property_value: owl:priorVersion https://nmrml.org/cv/v1.1.0/nmrCV.owl
 property_value: owl:versionInfo "2.0_alpha" xsd:string
 property_value: owl:versionInfo "2025-03-20" xsd:string
-property_value: vann:preferredNamespacePrefix "nmrCV" xsd:string
+property_value: vann:preferredNamespacePrefix "nmrCV2025" xsd:string
 

--- a/nmrCV-base.owl
+++ b/nmrCV-base.owl
@@ -46,13 +46,13 @@ The decision to build upon nmrCV v1.1.0 was based on its existing definition of 
         <dcterms:contributor rdf:resource="https://orcid.org/0009-0001-5998-5030"/>
         <dcterms:created>2025-03-20</dcterms:created>
         <dcterms:license rdf:resource="https://creativecommons.org/publicdomain/mark/1.0/"/>
-        <dcterms:references>https://doi.org/10.1021/acs.analchem.7b02795</dcterms:references>
+        <dcterms:references rdf:resource="https://doi.org/10.1021/acs.analchem.7b02795"/>
         <dcterms:title>nuclear magnetic resonance CV</dcterms:title>
-        <vann:preferredNamespacePrefix>nmrCV</vann:preferredNamespacePrefix>
+        <vann:preferredNamespacePrefix>nmrCV2025</vann:preferredNamespacePrefix>
         <doap:audience>This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments.</doap:audience>
-        <doap:bug-database>https://github.com/nmrML/nmrCV/issues</doap:bug-database>
-        <doap:implements>https://github.com/nmrML/nmrML</doap:implements>
-        <doap:location>https://github.com/nmrML/nmrCV</doap:location>
+        <doap:bug-database rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/nmrML/nmrCV/issues</doap:bug-database>
+        <doap:implements rdf:resource="https://github.com/nmrML/nmrML"/>
+        <doap:location rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/nmrML/nmrCV</doap:location>
         <doap:maintainer rdf:resource="https://www.wikidata.org/wiki/Q96678459"/>
         <owl:priorVersion rdf:resource="https://nmrml.org/cv/v1.1.0/nmrCV.owl"/>
         <owl:versionInfo>2.0_alpha</owl:versionInfo>

--- a/nmrCV-base.ttl
+++ b/nmrCV-base.ttl
@@ -46,13 +46,13 @@ The decision to build upon nmrCV v1.1.0 was based on its existing definition of 
                                                              <https://orcid.org/0009-0001-5998-5030> ;
                                          dcterms:created "2025-03-20" ;
                                          dcterms:license <https://creativecommons.org/publicdomain/mark/1.0/> ;
-                                         dcterms:references "https://doi.org/10.1021/acs.analchem.7b02795" ;
+                                         dcterms:references <https://doi.org/10.1021/acs.analchem.7b02795> ;
                                          dcterms:title "nuclear magnetic resonance CV" ;
-                                         vann:preferredNamespacePrefix "nmrCV" ;
+                                         vann:preferredNamespacePrefix "nmrCV2025" ;
                                          doap:audience "This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments." ;
-                                         doap:bug-database "https://github.com/nmrML/nmrCV/issues" ;
-                                         doap:implements "https://github.com/nmrML/nmrML" ;
-                                         doap:location "https://github.com/nmrML/nmrCV" ;
+                                         doap:bug-database "https://github.com/nmrML/nmrCV/issues"^^xsd:anyURI ;
+                                         doap:implements <https://github.com/nmrML/nmrML> ;
+                                         doap:location "https://github.com/nmrML/nmrCV"^^xsd:anyURI ;
                                          doap:maintainer <https://www.wikidata.org/wiki/Q96678459> ;
                                          owl:priorVersion <https://nmrml.org/cv/v1.1.0/nmrCV.owl> ;
                                          owl:versionInfo "2.0_alpha" ,

--- a/nmrCV-full.obo
+++ b/nmrCV-full.obo
@@ -55,17 +55,17 @@ property_value: dcterms:contributor https://orcid.org/0000-0003-1144-3600
 property_value: dcterms:contributor https://orcid.org/0009-0001-5998-5030
 property_value: dcterms:created "2025-03-20" xsd:string
 property_value: dcterms:license https://creativecommons.org/publicdomain/mark/1.0/
-property_value: dcterms:references "https://doi.org/10.1021/acs.analchem.7b02795" xsd:string
+property_value: dcterms:references https://doi.org/10.1021/acs.analchem.7b02795
 property_value: dcterms:title "nuclear magnetic resonance CV" xsd:string
 property_value: doap:audience "This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments." xsd:string
-property_value: doap:bug-database "https://github.com/nmrML/nmrCV/issues" xsd:string
-property_value: doap:implements "https://github.com/nmrML/nmrML" xsd:string
-property_value: doap:location "https://github.com/nmrML/nmrCV" xsd:string
+property_value: doap:bug-database "https://github.com/nmrML/nmrCV/issues" xsd:anyURI
+property_value: doap:implements https://github.com/nmrML/nmrML
+property_value: doap:location "https://github.com/nmrML/nmrCV" xsd:anyURI
 property_value: doap:maintainer https://www.wikidata.org/wiki/Q96678459
 property_value: owl:priorVersion https://nmrml.org/cv/v1.1.0/nmrCV.owl
 property_value: owl:versionInfo "2.0_alpha" xsd:string
 property_value: owl:versionInfo "2025-03-20" xsd:string
-property_value: vann:preferredNamespacePrefix "nmrCV" xsd:string
+property_value: vann:preferredNamespacePrefix "nmrCV2025" xsd:string
 
 [Term]
 id: BFO:0000001

--- a/nmrCV-full.owl
+++ b/nmrCV-full.owl
@@ -53,13 +53,13 @@ The decision to build upon nmrCV v1.1.0 was based on its existing definition of 
         <dcterms:contributor rdf:resource="https://orcid.org/0009-0001-5998-5030"/>
         <dcterms:created>2025-03-20</dcterms:created>
         <dcterms:license rdf:resource="https://creativecommons.org/publicdomain/mark/1.0/"/>
-        <dcterms:references>https://doi.org/10.1021/acs.analchem.7b02795</dcterms:references>
+        <dcterms:references rdf:resource="https://doi.org/10.1021/acs.analchem.7b02795"/>
         <dcterms:title>nuclear magnetic resonance CV</dcterms:title>
-        <vann:preferredNamespacePrefix>nmrCV</vann:preferredNamespacePrefix>
+        <vann:preferredNamespacePrefix>nmrCV2025</vann:preferredNamespacePrefix>
         <doap:audience>This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments.</doap:audience>
-        <doap:bug-database>https://github.com/nmrML/nmrCV/issues</doap:bug-database>
-        <doap:implements>https://github.com/nmrML/nmrML</doap:implements>
-        <doap:location>https://github.com/nmrML/nmrCV</doap:location>
+        <doap:bug-database rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/nmrML/nmrCV/issues</doap:bug-database>
+        <doap:implements rdf:resource="https://github.com/nmrML/nmrML"/>
+        <doap:location rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/nmrML/nmrCV</doap:location>
         <doap:maintainer rdf:resource="https://www.wikidata.org/wiki/Q96678459"/>
         <owl:priorVersion rdf:resource="https://nmrml.org/cv/v1.1.0/nmrCV.owl"/>
         <owl:versionInfo>2.0_alpha</owl:versionInfo>

--- a/nmrCV-full.ttl
+++ b/nmrCV-full.ttl
@@ -53,13 +53,13 @@ The decision to build upon nmrCV v1.1.0 was based on its existing definition of 
                                                              <https://orcid.org/0009-0001-5998-5030> ;
                                          dcterms:created "2025-03-20" ;
                                          dcterms:license <https://creativecommons.org/publicdomain/mark/1.0/> ;
-                                         dcterms:references "https://doi.org/10.1021/acs.analchem.7b02795" ;
+                                         dcterms:references <https://doi.org/10.1021/acs.analchem.7b02795> ;
                                          dcterms:title "nuclear magnetic resonance CV" ;
-                                         vann:preferredNamespacePrefix "nmrCV" ;
+                                         vann:preferredNamespacePrefix "nmrCV2025" ;
                                          doap:audience "This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments." ;
-                                         doap:bug-database "https://github.com/nmrML/nmrCV/issues" ;
-                                         doap:implements "https://github.com/nmrML/nmrML" ;
-                                         doap:location "https://github.com/nmrML/nmrCV" ;
+                                         doap:bug-database "https://github.com/nmrML/nmrCV/issues"^^xsd:anyURI ;
+                                         doap:implements <https://github.com/nmrML/nmrML> ;
+                                         doap:location "https://github.com/nmrML/nmrCV"^^xsd:anyURI ;
                                          doap:maintainer <https://www.wikidata.org/wiki/Q96678459> ;
                                          owl:priorVersion <https://nmrml.org/cv/v1.1.0/nmrCV.owl> ;
                                          owl:versionInfo "2.0_alpha" ,

--- a/nmrCV.obo
+++ b/nmrCV.obo
@@ -55,17 +55,17 @@ property_value: dcterms:contributor https://orcid.org/0000-0003-1144-3600
 property_value: dcterms:contributor https://orcid.org/0009-0001-5998-5030
 property_value: dcterms:created "2025-03-20" xsd:string
 property_value: dcterms:license https://creativecommons.org/publicdomain/mark/1.0/
-property_value: dcterms:references "https://doi.org/10.1021/acs.analchem.7b02795" xsd:string
+property_value: dcterms:references https://doi.org/10.1021/acs.analchem.7b02795
 property_value: dcterms:title "nuclear magnetic resonance CV" xsd:string
 property_value: doap:audience "This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments." xsd:string
-property_value: doap:bug-database "https://github.com/nmrML/nmrCV/issues" xsd:string
-property_value: doap:implements "https://github.com/nmrML/nmrML" xsd:string
-property_value: doap:location "https://github.com/nmrML/nmrCV" xsd:string
+property_value: doap:bug-database "https://github.com/nmrML/nmrCV/issues" xsd:anyURI
+property_value: doap:implements https://github.com/nmrML/nmrML
+property_value: doap:location "https://github.com/nmrML/nmrCV" xsd:anyURI
 property_value: doap:maintainer https://www.wikidata.org/wiki/Q96678459
 property_value: owl:priorVersion https://nmrml.org/cv/v1.1.0/nmrCV.owl
 property_value: owl:versionInfo "2.0_alpha" xsd:string
 property_value: owl:versionInfo "2025-03-20" xsd:string
-property_value: vann:preferredNamespacePrefix "nmrCV" xsd:string
+property_value: vann:preferredNamespacePrefix "nmrCV2025" xsd:string
 
 [Term]
 id: BFO:0000001

--- a/nmrCV.owl
+++ b/nmrCV.owl
@@ -53,13 +53,13 @@ The decision to build upon nmrCV v1.1.0 was based on its existing definition of 
         <dcterms:contributor rdf:resource="https://orcid.org/0009-0001-5998-5030"/>
         <dcterms:created>2025-03-20</dcterms:created>
         <dcterms:license rdf:resource="https://creativecommons.org/publicdomain/mark/1.0/"/>
-        <dcterms:references>https://doi.org/10.1021/acs.analchem.7b02795</dcterms:references>
+        <dcterms:references rdf:resource="https://doi.org/10.1021/acs.analchem.7b02795"/>
         <dcterms:title>nuclear magnetic resonance CV</dcterms:title>
-        <vann:preferredNamespacePrefix>nmrCV</vann:preferredNamespacePrefix>
+        <vann:preferredNamespacePrefix>nmrCV2025</vann:preferredNamespacePrefix>
         <doap:audience>This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments.</doap:audience>
-        <doap:bug-database>https://github.com/nmrML/nmrCV/issues</doap:bug-database>
-        <doap:implements>https://github.com/nmrML/nmrML</doap:implements>
-        <doap:location>https://github.com/nmrML/nmrCV</doap:location>
+        <doap:bug-database rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/nmrML/nmrCV/issues</doap:bug-database>
+        <doap:implements rdf:resource="https://github.com/nmrML/nmrML"/>
+        <doap:location rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI">https://github.com/nmrML/nmrCV</doap:location>
         <doap:maintainer rdf:resource="https://www.wikidata.org/wiki/Q96678459"/>
         <owl:priorVersion rdf:resource="https://nmrml.org/cv/v1.1.0/nmrCV.owl"/>
         <owl:versionInfo>2.0_alpha</owl:versionInfo>

--- a/nmrCV.ttl
+++ b/nmrCV.ttl
@@ -53,13 +53,13 @@ The decision to build upon nmrCV v1.1.0 was based on its existing definition of 
                                                   <https://orcid.org/0009-0001-5998-5030> ;
                               dcterms:created "2025-03-20" ;
                               dcterms:license <https://creativecommons.org/publicdomain/mark/1.0/> ;
-                              dcterms:references "https://doi.org/10.1021/acs.analchem.7b02795" ;
+                              dcterms:references <https://doi.org/10.1021/acs.analchem.7b02795> ;
                               dcterms:title "nuclear magnetic resonance CV" ;
-                              vann:preferredNamespacePrefix "nmrCV" ;
+                              vann:preferredNamespacePrefix "nmrCV2025" ;
                               doap:audience "This CV is to be used by metabolomics researchers, or basically any chenomics or proteomics researchers  who apply the  nmrML xml to store their NMRraw data in a vendor agnostic manner. But nmrML can also be used to capture experimental results  and (limited) basic metadata like molecule to spectral feature assignments." ;
-                              doap:bug-database "https://github.com/nmrML/nmrCV/issues" ;
-                              doap:implements "https://github.com/nmrML/nmrML" ;
-                              doap:location "https://github.com/nmrML/nmrCV" ;
+                              doap:bug-database "https://github.com/nmrML/nmrCV/issues"^^xsd:anyURI ;
+                              doap:implements <https://github.com/nmrML/nmrML> ;
+                              doap:location "https://github.com/nmrML/nmrCV"^^xsd:anyURI ;
                               doap:maintainer <https://www.wikidata.org/wiki/Q96678459> ;
                               owl:priorVersion <https://nmrml.org/cv/v1.1.0/nmrCV.owl> ;
                               owl:versionInfo "2.0_alpha" ,


### PR DESCRIPTION
This PR fixes some minor issues in the metadata of the 2025-03-20 release. The preferred prefix is changed to "nmrCV2025" to allow a side-by-side indexing of this version alongside the previous 1.1.0 version within the TIB Terminology Service. And some wrong datatypes for the values of properties like [bug-database](doap:bug-database), or dcterms:references where fixed